### PR TITLE
empty string separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (str, sep) {
 	if (typeof str !== 'string') {
 		throw new TypeError('Expected a string');
 	}
-	sep = sep || '_';
+	sep = typeof sep === 'undefined' ? '_' : sep;
 	return str.replace(/([a-z\d])([A-Z])/g, '$1' + sep + '$2')
 					.replace(new RegExp('(' + sep + '[A-Z])([A-Z])', 'g'), '$1' + sep + '$2')
 					.toLowerCase();

--- a/test.js
+++ b/test.js
@@ -9,5 +9,6 @@ test(function (t) {
 	t.assert(decamelize('unicorns-and-rainbows') === 'unicorns-and-rainbows');
 	t.assert(decamelize('thisIsATest') === 'this_is_a_test');
 	t.assert(decamelize('thisIsATest', ' ') === 'this is a test');
+	t.assert(decamelize('thisIsATest', '') === 'thisisatest');
 	t.end();
 });


### PR DESCRIPTION
Added support of `''` separaror (empty string is `false` converted to boolean, so it was ignored).

```js
decamelize('dontSplitUsPlease', '');
//=> `dontsplitusplease`
```

So now it kind of aligns with `[].join()`!

*The change might be breaking for some people* :information_desk_person: