### PR TITLE
 Fix: Use IE11 friendly syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,19 +3,23 @@ const xRegExp = require('xregexp');
 
 const decamelize = (text, separator = '_') => {
 	if (!(typeof text === 'string' && typeof separator === 'string')) {
-		throw new TypeError('The `text` and `separator` arguments should be of type `string`');
+		throw new TypeError(
+			'The `text` and `separator` arguments should be of type `string`'
+		);
 	}
 
 	const regex1 = xRegExp('([\\p{Ll}\\d])(\\p{Lu})', 'g');
 	const regex2 = xRegExp('(\\p{Lu}+)(\\p{Lu}[\\p{Ll}\\d]+)', 'g');
 
-	return text
-		// TODO: Use this instead of `xregexp` when targeting Node.js 10:
-		// .replace(/([\p{Lowercase_Letter}\d])(\p{Uppercase_Letter})/gu, `$1${separator}$2`)
-		// .replace(/(\p{Lowercase_Letter}+)(\p{Uppercase_Letter}[\p{Lowercase_Letter}\d]+)/gu, `$1${separator}$2`)
-		.replace(regex1, `$1${separator}$2`)
-		.replace(regex2, `$1${separator}$2`)
-		.toLowerCase();
+	return (
+		text
+			// TODO: Use this instead of `xregexp` when targeting Node.js 10:
+			// .replace(/([\p{Lowercase_Letter}\d])(\p{Uppercase_Letter})/gu, `$1${separator}$2`)
+			// .replace(/(\p{Lowercase_Letter}+)(\p{Uppercase_Letter}[\p{Lowercase_Letter}\d]+)/gu, `$1${separator}$2`)
+			.replace(regex1, '$1' + separator + '$2')
+			.replace(regex2, '$1' + separator + '$2')
+			.toLowerCase()
+	);
 };
 
 module.exports = decamelize;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 const xRegExp = require('xregexp');
 
-const decamelize = (text, separator = '_') => {
+function decamelize(text, separatorArg) {
+	const separator = typeof separatorArg === 'undefined' ? '_' : separatorArg;
+
 	if (!(typeof text === 'string' && typeof separator === 'string')) {
 		throw new TypeError(
 			'The `text` and `separator` arguments should be of type `string`'
@@ -20,7 +22,7 @@ const decamelize = (text, separator = '_') => {
 			.replace(regex2, '$1' + separator + '$2')
 			.toLowerCase()
 	);
-};
+}
 
 module.exports = decamelize;
 // TODO: Remove this for the next major release


### PR DESCRIPTION
## Decsription
We are using this library in our client facing application which needs to be IE11 compatible - due to current usage of arrow function, default argument value and template literal - this library is breaking on IE11 - please consider the following changes to support this older browser.

Thank you!
