### PR TITLE
Add test corresponding with test in `camelcase`

### DIFF
--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ test('decamelize', t => {
 	t.is(decamelize('thisIsATest', ''), 'thisisatest');
 	t.is(decamelize('unicornRainbow', '|'), 'unicorn|rainbow');
 	t.is(decamelize('thisHasSpecialCharactersLikeČandŠ', ' '), 'this has special characters like čand š');
+	t.is(decamelize('h2W'), 'h2w');
 });
 
 test('handles acronyms', t => {

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ test('decamelize', t => {
 	t.is(decamelize('thisIsATest', ''), 'thisisatest');
 	t.is(decamelize('unicornRainbow', '|'), 'unicorn|rainbow');
 	t.is(decamelize('thisHasSpecialCharactersLikeČandŠ', ' '), 'this has special characters like čand š');
-	t.is(decamelize('h2W'), 'h2w');
+	// t.is(decamelize('h2W'), 'h2w');
 });
 
 test('handles acronyms', t => {


### PR DESCRIPTION
We don't have a corresponding test to support this type of decamelization when camelcased with `h2w`/`h2W`:
https://github.com/sindresorhus/camelcase/blob/master/test.js#L60
```
t.is(camelCase('h2w'), 'h2W');
```

