### PR TITLE
Remove Safari support note from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,6 @@ If you use this on untrusted user input, don't forget to limit the length to som
 npm install decamelize
 ```
 
-*If you need Safari support, [stay on](https://github.com/sindresorhus/decamelize/issues/24) [version 3](https://github.com/sindresorhus/decamelize/issues/36) [until they implement](https://caniuse.com/js-regexp-lookbehind) regex lookbehinds.*
-
 ## Usage
 
 ```js


### PR DESCRIPTION
This is fixed per the WebKit bug tracker: https://bugs.webkit.org/show_bug.cgi?id=174931
[caniuse.com](https://caniuse.com/js-regexp-lookbehind) claims it was released in 2023 with Safari 16.4